### PR TITLE
Split npm commands, add source-map option to babel-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "license": "MIT",
   "scripts": {
     "type-check": "tsc --noEmit",
-    "build": "tsc --emitDeclarationOnly && babel src --out-dir lib --extensions \".ts,.tsx\""
+    "build:typings": "tsc --emitDeclarationOnly",
+    "build:js": "babel src --out-dir lib --extensions \".ts,.tsx\" --source-maps inline",
+    "build": "npm run build:typings && npm run build:js"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.49",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "license": "MIT",
   "scripts": {
     "type-check": "tsc --noEmit",
-    "build:typings": "tsc --emitDeclarationOnly",
-    "build:js": "babel src --out-dir lib --extensions \".ts,.tsx\" --source-maps inline",
-    "build": "npm run build:typings && npm run build:js"
+    "build-types": "tsc --emitDeclarationOnly",
+    "build-js": "babel src --out-dir lib --extensions \".ts,.tsx\" --source-maps inline",
+    "build": "npm run build-types && npm run build-js"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.49",


### PR DESCRIPTION
*Edit by @DanielRosenwasser: Fixes #12*