### PR TITLE
Fix webpack test-rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ module.exports = {
     module: {
         rules: [{
             // Include ts, tsx, and js files.
-            test: /\.(tsx?)|(js)$/,
+            test: /\.(tsx?)$|(js)$/,
             exclude: /node_modules/,
             loader: 'babel-loader',
         }],

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ module.exports = {
     },
     module: {
         rules: [{
-            // Include ts, tsx, and js files.
-            test: /\.(tsx?)$|(js)$/,
+            // Include ts, tsx, js, and jsx files.
+            test: /\.(ts|js)x?$/,
             exclude: /node_modules/,
             loader: 'babel-loader',
         }],


### PR DESCRIPTION
Minor issue in the README. The Webpack regex would match any file whose extension starts with `.ts`. [Example in online regex tester](https://regex101.com/r/a6PBLW/1)