### PR TITLE
remove @babel/proposal-object-rest-spread

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,5 @@
   "presets": ["@babel/env", "@babel/typescript"],
   "plugins": [
     "@babel/proposal-class-properties",
-    "@babel/proposal-object-rest-spread"
   ]
 }


### PR DESCRIPTION
I don't think `@babel/proposal-object-rest-spread` is needed.
no longer in package.json.