### PR TITLE
Adding functionality to watch files in "src" directory and re-run the TypeScript build when they change

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,17 @@
   "name": "babel-typescript-sample",
   "version": "0.7.2",
   "license": "MIT",
+  "watch": {
+    "build": {
+      "patterns": [
+        "src"
+      ],
+      "extensions": "ts,html,css",
+      "quiet": false
+    }
+  },
   "scripts": {
+    "watch": "npm-watch build",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
     "build": "npm run build:types && npm run build:js",
@@ -16,5 +26,8 @@
     "@babel/preset-env": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
     "typescript": "^3.7.5"
+  },
+  "dependencies": {
+    "npm-watch": "^0.9.0"
   }
 }


### PR DESCRIPTION
This is accomplished via the "npm-watch" npm package.
This allows iterative local development workflows like this:
1. run "npm run watch"
2. the type checker and build js files processes will run
3. the process will block, and watch the files in "src" for changes
4. if a file in "src" changes, go to step #2