### PR TITLE
Fix .babelrc to match README

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
-  "presets": ["@babel/env", "@babel/typescript"],
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"],
   "plugins": [
-    "@babel/proposal-class-properties",
-    "@babel/proposal-object-rest-spread"
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-object-rest-spread"
   ]
 }


### PR DESCRIPTION
As titled. This seems to have been fixed in the README, but not in the actual babel rc file.